### PR TITLE
Add an optional Cloud Ops Agent install script

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.2.0 (2024-08-20)
+--------------------------
+Add a new input variable `cloud_ops_agent_enabled` to download and configure GCP Ops Agent. This is disabled by default to not affect existing installations.
+ 
 Version 0.1.0 (2023-07-26)
 --------------------------
 Add base compute module to use for all Snowplow services (closes #1)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ No modules.
 | <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | The name of the sub-network to deploy within; if populated will override the 'network' setting | `string` | `""` | no |
 | <a name="input_target_size"></a> [target\_size](#input\_target\_size) | The number of servers to deploy | `number` | `1` | no |
 | <a name="input_ubuntu_20_04_source_image"></a> [ubuntu\_20\_04\_source\_image](#input\_ubuntu\_20\_04\_source\_image) | The source image to use which must be based of of Ubuntu 20.04; by default the latest community version is used | `string` | `""` | no |
+| <a name="input_cloud_ops_agent_enabled"></a> [cloud\_ops\_agent\_enabled](#input\_cloud\_ops\_agent\_enabled) | Whether to install a GCP Cloud Ops Agent; disabled by default | `bool` | `false` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 locals {
   startup_script = templatefile("${path.module}/templates/startup-script.sh.tmpl", {
-    user_supplied_script = var.user_supplied_script
+    cloud_ops_agent_enabled = var.cloud_ops_agent_enabled
+    user_supplied_script    = var.user_supplied_script
   })
 }
 

--- a/templates/startup-script.sh.tmpl
+++ b/templates/startup-script.sh.tmpl
@@ -10,6 +10,11 @@ function install_docker_ce() {
   sudo systemctl enable --now docker
 }
 
+function install_cloud_ops_agent() {
+    curl -fsSOL https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
+    bash add-google-cloud-ops-agent-repo.sh --also-install
+}
+
 function get_instance_id() {
   curl --silent --location "http://metadata.google.internal/computeMetadata/v1/instance/id" -H "Metadata-Flavor:Google"
 }
@@ -50,6 +55,9 @@ sudo apt update -y
 sudo apt install wget unzip apt-transport-https ca-certificates curl software-properties-common jq -y
 
 install_docker_ce
+%{ if cloud_ops_agent_enabled ~}
+install_cloud_ops_agent
+%{ endif ~}
 
 # -----------------------------------------------------------------------------
 #  USER SUPPLIED SCRIPT

--- a/variables.tf
+++ b/variables.tf
@@ -96,3 +96,9 @@ variable "labels" {
   default     = {}
   type        = map(string)
 }
+
+variable "cloud_ops_agent_enabled" {
+  description = "Whether to install a GCP Cloud Ops Agent; disabled by default"
+  default     = false
+  type        = bool
+}


### PR DESCRIPTION
# What changed

This PR adds the `cloud_ops_agent_enabled` flag that fetches and installs the latest cloud ops agent during the startup. The actual script is taken from the [official documentation](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/installation#install-latest-version). 

This is set to `false` by default to avoid unexpected behavior for existing deployments. If this gets merged, we would need to update all relevant official snowplow modules, i.e. enrich, collector etc to support passing this flag from the user land – happy to do this work!

An alternative implementation that I would be equally happy with would be to expose the [user_supplied_script](https://github.com/snowplow-devops/terraform-google-service-ce#input_user_supplied_script) argument in the official modules to let the users append arbitrary setup scripts such as this.

# Why is this needed 

We lack the basic monitoring capabilities that are only available when the [Cloud Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent) is installed (disk, memory and CPU monitoring). We tried to install this without messing with the terraform configuration by using Ops Agent Policies, but apparently they only work when the [Ops Config Agents are installed](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/managing-agent-policies#the_policy_is_created_but_seems_to_have_no_effect), which can be limiting for some teams.  